### PR TITLE
Add DNS record types for OPENPGPKEY and SMIMEA to list of valid record types

### DIFF
--- a/nc_dnsapi/__init__.py
+++ b/nc_dnsapi/__init__.py
@@ -22,7 +22,7 @@ class DNSZone(object):
 
 
 class DNSRecord(object):
-    __valid_types = ['A', 'AAAA', 'MX', 'CNAME', 'CAA', 'SRV', 'TXT', 'TLSA', 'NS', 'DS']
+    __valid_types = ['A', 'AAAA', 'MX', 'CNAME', 'CAA', 'SRV', 'TXT', 'TLSA', 'NS', 'DS', 'OPENPGPKEY', 'SMIMEA']
 
     def __init__(self, hostname, type, destination, **kwargs):
         self.hostname = hostname


### PR DESCRIPTION
Netcup allows to store public keys (OPENPGPKEY) and certificates (SMIMEA) in DNS, records of this type cannot be published/ deleted through nc_dnsapi as types are not part of the valid types list. Furthermore apps depending on nc_dnsapi such as certbot-dns-netcup fail if such records exist.